### PR TITLE
[feat] 예약, 결제 파트 인가/검증 구현

### DIFF
--- a/backend/src/main/java/com/ll/hotel/domain/booking/booking/controller/BookingController.java
+++ b/backend/src/main/java/com/ll/hotel/domain/booking/booking/controller/BookingController.java
@@ -20,7 +20,7 @@ public class BookingController {
     private final BookingService bookingService;
     private final Rq rq;
 
-    // 예약
+    // 예약 및 결제
     @PostMapping
     @Transactional
     public RsData<BookingResponse> book(
@@ -30,7 +30,7 @@ public class BookingController {
 
         return new RsData<>(
                 "201",
-                String.format("%s번 예약이 완료되었습니다.", booking.getBookingNumber()),
+                "예약 및 결제에 성공하였습니다.",
                 BookingResponse.from(booking)
         );
     }
@@ -89,12 +89,14 @@ public class BookingController {
     @Transactional
     public RsData<BookingResponse> cancel(
             @PathVariable("booking_id") Long bookingId) {
+        Member member = rq.getActor();
         Booking booking = bookingService.findById(bookingId);
+
         bookingService.cancel(booking);
 
         return new RsData<>(
                 "200",
-                String.format("%s번 예약이 취소되었습니다.", booking.getBookingNumber()),
+                "예약 및 결제가 취소되었습니다.",
                 BookingResponse.from(booking)
         );
     }

--- a/backend/src/main/java/com/ll/hotel/domain/booking/booking/controller/BookingController.java
+++ b/backend/src/main/java/com/ll/hotel/domain/booking/booking/controller/BookingController.java
@@ -5,6 +5,7 @@ import com.ll.hotel.domain.booking.booking.dto.BookingResponse;
 import com.ll.hotel.domain.booking.booking.entity.Booking;
 import com.ll.hotel.domain.booking.booking.service.BookingService;
 import com.ll.hotel.domain.member.member.entity.Member;
+import com.ll.hotel.global.exceptions.ServiceException;
 import com.ll.hotel.global.rq.Rq;
 import com.ll.hotel.global.rsData.RsData;
 import com.ll.hotel.standard.page.dto.PageDto;
@@ -25,13 +26,42 @@ public class BookingController {
     @Transactional
     public RsData<BookingResponse> book(
             @RequestBody @Valid BookingRequest bookingRequest) {
-        Member member = rq.getActor();
-        Booking booking = bookingService.create(member, bookingRequest);
+        Member actor = rq.getActor();
+
+        // 사용자 정보가 없으면 예약 불가
+        if (actor == null) {
+            throw new ServiceException("401", "예약 권한이 없습니다.");
+        }
+
+        Booking booking = bookingService.create(actor, bookingRequest);
 
         return new RsData<>(
                 "201",
                 "예약 및 결제에 성공하였습니다.",
                 BookingResponse.from(booking)
+        );
+    }
+
+    // 전체 예약 조회
+    @GetMapping
+    @Transactional
+    public RsData<PageDto<BookingResponse>> getAllBookings(
+            @RequestParam(defaultValue = "1", name = "page") int page,
+            @RequestParam(defaultValue = "5", name = "page_size") int pageSize) {
+        Member actor = rq.getActor();
+
+        // 관리자만 조회 가능
+        if (actor == null || !(actor.isAdmin())) {
+            throw new ServiceException("401", "예약 조회 권한이 없습니다.");
+        }
+
+        return new RsData<>(
+                "200",
+                "호텔 예약 목록 조회에 성공했습니다.",
+                new PageDto<>(
+                        bookingService.findAll(page, pageSize)
+                                .map(BookingResponse::from)
+                )
         );
     }
 
@@ -41,13 +71,18 @@ public class BookingController {
     public RsData<PageDto<BookingResponse>> getMyBookings(
             @RequestParam(defaultValue = "1", name = "page") int page,
             @RequestParam(defaultValue = "5", name = "page_size") int pageSize) {
-        Member member = rq.getActor();
+        Member actor = rq.getActor();
+
+        // 사용자 정보가 없으면 조회 불가
+        if (actor == null) {
+            throw new ServiceException("401", "예약 조회 권한이 없습니다.");
+        }
 
         return new RsData<>(
                 "200",
                 "내 예약 목록 조회에 성공했습니다.",
                 new PageDto<>(
-                        bookingService.findByMember(member, page, pageSize)
+                        bookingService.findByMember(actor, page, pageSize)
                                 .map(BookingResponse::from)
                 )
         );
@@ -60,6 +95,13 @@ public class BookingController {
             @PathVariable("hotel_id") Long hotelId,
             @RequestParam(defaultValue = "1", name = "page") int page,
             @RequestParam(defaultValue = "5", name = "page_size") int pageSize) {
+        Member actor = rq.getActor();
+
+        // 관리자, 호텔 사업자만 조회 가능
+        if (actor == null || !(actor.isAdmin() || actor.isBusiness())) {
+            throw new ServiceException("401", "예약 조회 권한이 없습니다.");
+        }
+
         return new RsData<>(
                 "200",
                 "호텔 예약 목록 조회에 성공했습니다.",
@@ -75,7 +117,13 @@ public class BookingController {
     @Transactional
     public RsData<BookingResponse> getBooking(
             @PathVariable("booking_id") Long bookingId) {
+        Member actor = rq.getActor();
         Booking booking = bookingService.findById(bookingId);
+
+        // 관리자, 예약자, 호텔 사업자만 조회 가능
+        if (actor == null || !(actor.isAdmin() || booking.isReservedBy(actor) || booking.isOwnedBy(actor))) {
+            throw new ServiceException("401", "예약 조회 권한이 없습니다.");
+        }
 
         return new RsData<>(
                 "200",
@@ -89,10 +137,15 @@ public class BookingController {
     @Transactional
     public RsData<BookingResponse> cancel(
             @PathVariable("booking_id") Long bookingId) {
-        Member member = rq.getActor();
+        Member actor = rq.getActor();
         Booking booking = bookingService.findById(bookingId);
 
-        bookingService.cancel(booking);
+        // 관리자, 예약자, 호텔 사업자만 취소 가능
+        if (actor == null || !(actor.isAdmin() || booking.isReservedBy(actor) || booking.isOwnedBy(actor))) {
+            throw new ServiceException("401", "예약 취소 권한이 없습니다.");
+        }
+
+        booking = bookingService.cancel(booking);
 
         return new RsData<>(
                 "200",

--- a/backend/src/main/java/com/ll/hotel/domain/booking/booking/dto/BookingRequest.java
+++ b/backend/src/main/java/com/ll/hotel/domain/booking/booking/dto/BookingRequest.java
@@ -7,6 +7,11 @@ public record BookingRequest(
         Long hotelId,
         Long paymentId,
         LocalDate checkInDate,
-        LocalDate checkOutDate
+        LocalDate checkOutDate,
+
+        // PaymentRequest 생성에 필요
+        String merchantUid,
+        int amount,
+        Long paidAtTimestamp
 ) {
 }

--- a/backend/src/main/java/com/ll/hotel/domain/booking/booking/dto/BookingRequest.java
+++ b/backend/src/main/java/com/ll/hotel/domain/booking/booking/dto/BookingRequest.java
@@ -1,13 +1,15 @@
 package com.ll.hotel.domain.booking.booking.dto;
 
+import jakarta.validation.constraints.NotNull;
+
 import java.time.LocalDate;
 
 public record BookingRequest(
-        Long roomId,
-        Long hotelId,
-        Long paymentId,
-        LocalDate checkInDate,
-        LocalDate checkOutDate,
+        @NotNull(message = "객실 정보는 필수입니다.") Long roomId,
+        @NotNull(message = "호텔 정보는 필수입니다.") Long hotelId,
+        @NotNull(message = "결제 정보는 필수입니다.") Long paymentId,
+        @NotNull(message = "체크인 일자는 필수입니다.") LocalDate checkInDate,
+        @NotNull(message = "체크아웃 일자는 필수입니다.") LocalDate checkOutDate,
 
         // PaymentRequest 생성에 필요
         String merchantUid,

--- a/backend/src/main/java/com/ll/hotel/domain/booking/booking/dto/BookingResponse.java
+++ b/backend/src/main/java/com/ll/hotel/domain/booking/booking/dto/BookingResponse.java
@@ -2,6 +2,8 @@ package com.ll.hotel.domain.booking.booking.dto;
 
 import com.ll.hotel.domain.booking.booking.entity.Booking;
 import com.ll.hotel.domain.booking.booking.type.BookingStatus;
+import com.ll.hotel.domain.booking.payment.entity.Payment;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -10,6 +12,7 @@ public record BookingResponse(
         Long roomId,
         Long hotelId,
         Long memberId,
+        Payment payment,
         String bookNumber,
         BookingStatus bookingStatus,
         LocalDateTime createdAt,
@@ -23,6 +26,7 @@ public record BookingResponse(
                 booking.getRoom().getId(),
                 booking.getHotel().getId(),
                 booking.getMember().getId(),
+                booking.getPayment(),
                 booking.getBookingNumber(),
                 booking.getBookingStatus(),
                 booking.getCreatedAt(),

--- a/backend/src/main/java/com/ll/hotel/domain/booking/booking/entity/Booking.java
+++ b/backend/src/main/java/com/ll/hotel/domain/booking/booking/entity/Booking.java
@@ -56,4 +56,8 @@ public class Booking extends BaseTime {
     public boolean isReservedBy(Member member) {
         return this.member.equals(member);
     }
+
+    public boolean isOwnedBy(Member member) {
+        return this.member.isBusiness() && member.getBusiness().equals(hotel.getBusiness());
+    }
 }

--- a/backend/src/main/java/com/ll/hotel/domain/booking/booking/entity/Booking.java
+++ b/backend/src/main/java/com/ll/hotel/domain/booking/booking/entity/Booking.java
@@ -19,37 +19,42 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @Builder
 public class Booking extends BaseTime {
-    @NotNull
+    @NotNull(message = "객실 정보는 필수입니다.")
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "room_id")
     private Room room;
 
-    @NotNull
+    @NotNull(message = "호텔 정보는 필수입니다.")
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "hotel_id")
     private Hotel hotel;
 
-    @NotNull
+    @NotNull(message = "사용자 정보는 필수입니다.")
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name =  "member_id")
     private Member member;
 
-    @NotNull
+    @NotNull(message = "결제 정보는 필수입니다.")
     @OneToOne
     @JoinColumn(name = "payment_id")
     private Payment payment;
 
+    @NotNull(message = "예약 번호는 필수입니다.")
     @Column
-    private String bookingNumber;
+    @Builder.Default
+    private String bookingNumber = "";
 
+    @NotNull(message = "예약 상태 정보는 필수입니다.")
     @Enumerated(EnumType.STRING)
     @Column
     @Builder.Default
     private BookingStatus bookingStatus = BookingStatus.CONFIRMED;
 
+    @NotNull(message = "체크인 일자는 필수입니다.")
     @Column
     private LocalDate checkInDate;
 
+    @NotNull(message = "체크아웃 일자는 필수입니다.")
     @Column
     private LocalDate checkOutDate;
 

--- a/backend/src/main/java/com/ll/hotel/domain/booking/booking/service/BookingService.java
+++ b/backend/src/main/java/com/ll/hotel/domain/booking/booking/service/BookingService.java
@@ -5,13 +5,12 @@ import com.ll.hotel.domain.booking.booking.entity.Booking;
 import com.ll.hotel.domain.booking.booking.repository.BookingRepository;
 import com.ll.hotel.domain.booking.booking.type.BookingStatus;
 import com.ll.hotel.domain.booking.payment.entity.Payment;
-import com.ll.hotel.domain.booking.payment.repository.PaymentRepository;
+import com.ll.hotel.domain.booking.payment.service.PaymentService;
 import com.ll.hotel.domain.hotel.hotel.entity.Hotel;
 import com.ll.hotel.domain.hotel.hotel.repository.HotelRepository;
 import com.ll.hotel.domain.hotel.room.entity.Room;
 import com.ll.hotel.domain.hotel.room.repository.RoomRepository;
 import com.ll.hotel.domain.member.member.entity.Member;
-import com.ll.hotel.domain.member.member.repository.MemberRepository;
 import com.ll.hotel.global.exceptions.ServiceException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -19,42 +18,59 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.IllegalFormatException;
 import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class BookingService {
+    private final String CREATE_ERROR_MESSAGE = "예약 정보 저장에 실패했습니다. 관리자에게 문의하세요.";
     private final BookingRepository bookingRepository;
     private final RoomRepository roomRepository;
     private final HotelRepository hotelRepository;
-    private final PaymentRepository paymentRepository;
+    private final PaymentService paymentService;
 
-    // 테스트용
-    private final MemberRepository memberRepository;
-
+    /*
+     * 예약, 결제 정보 저장
+     * 결제 -> 예약 저장 순으로 진행됨
+     * 결제 오류 코드는 500-1, 500-2, 500-3 (PaymentService 코드 참고)
+     * 예약 오류 코드는 500-4, 500-5, 500-6
+     * 코드 500-4: room, hotel 검색 에러
+     * 코드 500-5: 예약 번호 생성 에러
+     * 코드 500-6: 예약 생성 및 저장 중 에러
+     */
     @Transactional
     public Booking create(Member member, BookingRequest bookingRequest) {
-        Optional<Room> room = roomRepository.findById(bookingRequest.roomId());
-        Optional<Hotel> hotel = hotelRepository.findById(bookingRequest.hotelId());
-        Optional<Payment> payment = paymentRepository.findById(bookingRequest.paymentId());
+        // 결제 정보 저장
+        Payment payment = paymentService.create(bookingRequest);
 
-        // 테스트용
-        member = memberRepository.findById(1L).get();
+        // 예약 정보 저장
+        try {
+            Optional<Room> room = roomRepository.findById(bookingRequest.roomId());
+            Optional<Hotel> hotel = hotelRepository.findById(bookingRequest.hotelId());
+            Booking booking = Booking.builder()
+                    .room(room.get())
+                    .hotel(hotel.get())
+                    .member(member)
+                    .payment(payment)
+                    .checkInDate(bookingRequest.checkInDate())
+                    .checkOutDate(bookingRequest.checkOutDate())
+                    .build();
 
-        Booking booking = Booking.builder()
-                .room(room.get())
-                .hotel(hotel.get())
-                .member(member)
-                .payment(payment.get())
-                .checkInDate(bookingRequest.checkInDate())
-                .checkOutDate(bookingRequest.checkOutDate())
-                .build();
-
-        booking = bookingRepository.save(booking);
-        booking.setBookingNumber(String.format("B%08d", booking.getId()));
-        return bookingRepository.save(booking);
+            booking = bookingRepository.save(booking);
+            booking.setBookingNumber(String.format("B%08d", booking.getId())); // ID 기반으로 예약 번호 생성
+            return bookingRepository.save(booking);
+        } catch (ServiceException e) {
+            throw new ServiceException("500-4", CREATE_ERROR_MESSAGE);
+        } catch (IllegalFormatException e) {
+            throw new ServiceException("500-5", CREATE_ERROR_MESSAGE);
+        } catch (Exception e) {
+            throw new ServiceException("500-6", CREATE_ERROR_MESSAGE);
+        }
     }
 
+    @Transactional
     public void cancel(Booking booking) {
         if (booking.getBookingStatus() == BookingStatus.CANCELLED) {
             throw new ServiceException("400", "이미 취소된 예약입니다.");

--- a/backend/src/main/java/com/ll/hotel/domain/booking/payment/controller/PaymentController.java
+++ b/backend/src/main/java/com/ll/hotel/domain/booking/payment/controller/PaymentController.java
@@ -6,7 +6,6 @@ import com.ll.hotel.domain.booking.payment.dto.UidResponse;
 import com.ll.hotel.domain.booking.payment.entity.Payment;
 import com.ll.hotel.domain.booking.payment.service.PaymentService;
 import com.ll.hotel.global.rsData.RsData;
-import com.ll.hotel.standard.util.Ut;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,7 +30,7 @@ public class PaymentController {
     // 상점 uid 및 api key 발급
     @GetMapping("/uid")
     public RsData<UidResponse> getUid() {
-        String merchantUid = Ut.random.generateUID(10);
+        String merchantUid = paymentService.generateMerchantUid();
         return new RsData<>(
                 "201",
                 "Uid 발급에 성공했습니다.",
@@ -59,7 +58,7 @@ public class PaymentController {
         Payment payment = paymentService.findById(paymentId);
         return new RsData<>(
                 "200",
-                "결제 정보를 조회했습니다.",
+                "결제 정보 조회에 성공했습니다.",
                 PaymentResponse.from(payment)
         );
     }
@@ -71,7 +70,7 @@ public class PaymentController {
         Payment payment = paymentService.softDelete(paymentId);
         return new RsData<>(
                 "200",
-                "환불에 성공했습니다.",
+                "결제 취소에 성공했습니다.",
                 PaymentResponse.from(payment)
         );
     }

--- a/backend/src/main/java/com/ll/hotel/domain/booking/payment/controller/PaymentController.java
+++ b/backend/src/main/java/com/ll/hotel/domain/booking/payment/controller/PaymentController.java
@@ -5,6 +5,9 @@ import com.ll.hotel.domain.booking.payment.dto.PaymentResponse;
 import com.ll.hotel.domain.booking.payment.dto.UidResponse;
 import com.ll.hotel.domain.booking.payment.entity.Payment;
 import com.ll.hotel.domain.booking.payment.service.PaymentService;
+import com.ll.hotel.domain.member.member.entity.Member;
+import com.ll.hotel.global.exceptions.ServiceException;
+import com.ll.hotel.global.rq.Rq;
 import com.ll.hotel.global.rsData.RsData;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -17,19 +20,29 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class PaymentController {
     private final PaymentService paymentService;
+    private final Rq rq;
 
     /*
      * portone api 호출에 필요한 keys
-     * application.yml에 저장된 값을 가져옴
+     * application-api-keys.yml에 저장된 값을 가져옴
      */
     @Value("${api-keys.portone.apiId}")
     private String apiId;
     @Value("${api-keys.portone.channel-key}")
     private String channelKey;
 
-    // 상점 uid 및 api key 발급
+    /*
+     * 상점 uid 및 api key 발급
+     * 결제 관련 api는 /uid 외에 실제로 호출하도록 설계되지 않았음
+     * 다만 테스트용으로 작성한 바가 있음
+     */
     @GetMapping("/uid")
     public RsData<UidResponse> getUid() {
+        Member actor = rq.getActor();
+        if (actor == null) {
+            throw new ServiceException("401", "Uid 발급 권한이 없습니다.");
+        }
+
         String merchantUid = paymentService.generateMerchantUid();
         return new RsData<>(
                 "201",
@@ -43,6 +56,11 @@ public class PaymentController {
     @Transactional
     public RsData<PaymentResponse> pay(
             @RequestBody @Valid PaymentRequest paymentRequest) {
+        Member actor = rq.getActor();
+        if (actor == null || !actor.isAdmin()) {
+            throw new ServiceException("401", "결제 api 호출 권한이 없습니다.");
+        }
+
         Payment payment = paymentService.create(paymentRequest);
         return new RsData<>(
                 "201",
@@ -55,6 +73,11 @@ public class PaymentController {
     @GetMapping("/{payment_id}")
     public RsData<PaymentResponse> getPayment(
             @PathVariable("payment_id") Long paymentId) {
+        Member actor = rq.getActor();
+        if (actor == null || !actor.isAdmin()) {
+            throw new ServiceException("401", "결제 api 호출 권한이 없습니다.");
+        }
+
         Payment payment = paymentService.findById(paymentId);
         return new RsData<>(
                 "200",
@@ -67,6 +90,11 @@ public class PaymentController {
     @Transactional
     public RsData<PaymentResponse> cancel(
             @PathVariable("payment_id") Long paymentId) {
+        Member actor = rq.getActor();
+        if (actor == null || !actor.isAdmin()) {
+            throw new ServiceException("401", "결제 api 호출 권한이 없습니다.");
+        }
+
         Payment payment = paymentService.softDelete(paymentId);
         return new RsData<>(
                 "200",

--- a/backend/src/main/java/com/ll/hotel/domain/booking/payment/dto/PaymentRequest.java
+++ b/backend/src/main/java/com/ll/hotel/domain/booking/payment/dto/PaymentRequest.java
@@ -1,9 +1,18 @@
 package com.ll.hotel.domain.booking.payment.dto;
 
+import com.ll.hotel.domain.booking.booking.dto.BookingRequest;
+
 public record PaymentRequest(
         String merchantUid,
         int amount,
         Long paidAtTimestamp
 ) {
+    public static PaymentRequest from(BookingRequest bookingRequest) {
+        return new PaymentRequest(
+                bookingRequest.merchantUid(),
+                bookingRequest.amount(),
+                bookingRequest.paidAtTimestamp()
+        );
+    }
 }
 

--- a/backend/src/main/java/com/ll/hotel/domain/booking/payment/dto/PaymentRequest.java
+++ b/backend/src/main/java/com/ll/hotel/domain/booking/payment/dto/PaymentRequest.java
@@ -1,11 +1,12 @@
 package com.ll.hotel.domain.booking.payment.dto;
 
 import com.ll.hotel.domain.booking.booking.dto.BookingRequest;
+import jakarta.validation.constraints.NotNull;
 
 public record PaymentRequest(
-        String merchantUid,
-        int amount,
-        Long paidAtTimestamp
+        @NotNull(message = "거래 UID는 필수입니다.") String merchantUid,
+        @NotNull(message = "거래 금액은 필수입니다.") int amount,
+        @NotNull(message = "거래 일자는 필수입니다.") Long paidAtTimestamp
 ) {
     public static PaymentRequest from(BookingRequest bookingRequest) {
         return new PaymentRequest(

--- a/backend/src/main/java/com/ll/hotel/domain/booking/payment/entity/Payment.java
+++ b/backend/src/main/java/com/ll/hotel/domain/booking/payment/entity/Payment.java
@@ -23,18 +23,21 @@ public class Payment extends BaseTime {
      * merchant_uid는 상점(호텔) 측에서 생성하는 주문번호
      * api key는 application.yml에 작성
      */
-    @NotNull
+    @NotNull(message = "거래 UID는 필수입니다.")
     @Column(unique = true)
     private String merchantUid;
 
+    @NotNull(message = "거래 금액은 필수입니다.")
     @Column
     private int amount;
 
+    @NotNull(message = "거래 상태 정보는 필수입니다.")
     @Enumerated(EnumType.STRING)
     @Column
     @Builder.Default
     private PaymentStatus paymentStatus = PaymentStatus.PAID;
 
+    @NotNull(message = "거래 일자는 필수입니다.")
     @Column
     private LocalDateTime paidAt;
 }

--- a/backend/src/main/java/com/ll/hotel/domain/booking/payment/repository/PaymentRepository.java
+++ b/backend/src/main/java/com/ll/hotel/domain/booking/payment/repository/PaymentRepository.java
@@ -4,4 +4,5 @@ import com.ll.hotel.domain.booking.payment.entity.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    public boolean existsByMerchantUid(String merchantUid);
 }

--- a/backend/src/main/java/com/ll/hotel/domain/booking/payment/service/PaymentService.java
+++ b/backend/src/main/java/com/ll/hotel/domain/booking/payment/service/PaymentService.java
@@ -28,6 +28,10 @@ public class PaymentService {
     @Value("${api-keys.portone.impSecret}")
     private String impSecret;
 
+    public long count() {
+        return paymentRepository.count();
+    }
+
     public String generateMerchantUid() {
         int genCount = 10;
         int uidLength = 10;

--- a/backend/src/main/java/com/ll/hotel/domain/booking/payment/service/PaymentService.java
+++ b/backend/src/main/java/com/ll/hotel/domain/booking/payment/service/PaymentService.java
@@ -11,6 +11,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Map;
+import com.ll.hotel.standard.util.Ut;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
@@ -26,6 +27,21 @@ public class PaymentService {
     private String impKey;
     @Value("${api-keys.portone.impSecret}")
     private String impSecret;
+
+    public String generateMerchantUid() {
+        int genCount = 10;
+        int uidLength = 10;
+
+        //10번 이내애 중복되지 않는 merchantUid를 생성해야 함, 그렇지 않으면 예외 처리
+        while (genCount-- > 0) {
+            String merchantUid = Ut.random.generateUID(uidLength);
+            if (!paymentRepository.existsByMerchantUid(merchantUid)) {
+                return merchantUid;
+            }
+        }
+
+        throw new ServiceException("400", "merchantUid 생성에 실패했습니다.");
+    }
 
     // 결제 정보 저장
     @Transactional

--- a/backend/src/main/java/com/ll/hotel/global/initData/BaseInit.java
+++ b/backend/src/main/java/com/ll/hotel/global/initData/BaseInit.java
@@ -1,0 +1,41 @@
+package com.ll.hotel.global.initData;
+
+import com.ll.hotel.domain.booking.payment.dto.PaymentRequest;
+import com.ll.hotel.domain.booking.payment.service.PaymentService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+
+import java.time.Instant;
+
+@Configuration
+@RequiredArgsConstructor
+public class BaseInit {
+    private final PaymentService paymentService;
+
+    @Autowired
+    @Lazy
+    private BaseInit self;
+
+    @Bean
+    public ApplicationRunner baseInitApplicationRunner() {
+        return args -> {
+            self.work1();
+        };
+    }
+
+    @Transactional
+    public void work1() {
+        if (paymentService.count() > 0) return;
+
+        Long currentTimestamp = Instant.now().getEpochSecond();
+        paymentService.create(new PaymentRequest("BASEINIT01", 1001, currentTimestamp));
+        paymentService.create(new PaymentRequest("BASEINIT02", 1002, currentTimestamp));
+        paymentService.create(new PaymentRequest("BASEINIT03", 1003, currentTimestamp));
+        paymentService.create(new PaymentRequest("BASEINIT04", 1004, currentTimestamp));
+    }
+}

--- a/backend/src/test/java/com/ll/hotel/domain/booking/booking/BookingControllerTest.java
+++ b/backend/src/test/java/com/ll/hotel/domain/booking/booking/BookingControllerTest.java
@@ -1,0 +1,4 @@
+package com.ll.hotel.domain.booking.booking;
+
+public class BookingControllerTest {
+}

--- a/backend/src/test/java/com/ll/hotel/domain/booking/payment/PaymentControllerTest.java
+++ b/backend/src/test/java/com/ll/hotel/domain/booking/payment/PaymentControllerTest.java
@@ -1,0 +1,131 @@
+package com.ll.hotel.domain.booking.payment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ll.hotel.domain.booking.payment.controller.PaymentController;
+import com.ll.hotel.domain.booking.payment.dto.PaymentRequest;
+import com.ll.hotel.domain.booking.payment.service.PaymentService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+public class PaymentControllerTest {
+    @Autowired
+    private PaymentService paymentService;
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    @DisplayName("merchantUid 생성")
+    void t1() throws Exception {
+        // UID GET 요청
+        ResultActions resultActions = mvc
+                .perform(get("/api/bookings/payments/uid"))
+                .andDo(print());
+
+        // 검증
+        resultActions
+                .andExpect(handler().handlerType(PaymentController.class))
+                .andExpect(handler().methodName("getUid"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.msg").value("Uid 발급에 성공했습니다."))
+                .andExpect(jsonPath("$.data.merchantUid").exists())
+                .andExpect(jsonPath("$.data.apiId").exists())
+                .andExpect(jsonPath("$.data.channelKey").exists());
+    }
+
+    @Test
+    @DisplayName("결제 내역 저장")
+    void t2() throws Exception {
+        // 테스트 데이터
+        ObjectMapper objectMapper = new ObjectMapper();
+        Long currentTimestamp = Instant.now().getEpochSecond();
+        PaymentRequest paymentRequest = new PaymentRequest(
+                "TESTUID123",
+                123,
+                currentTimestamp
+        );
+
+        // 데이터 POST 요청
+        ResultActions resultActions = mvc
+                .perform(
+                        post("/api/bookings/payments")
+                                .content(objectMapper.writeValueAsString(paymentRequest))
+                                .contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
+                )
+                .andDo(print());
+
+        // 검증
+        LocalDateTime currentDateTime = LocalDateTime.ofInstant(
+                Instant.ofEpochSecond(currentTimestamp),
+                ZoneId.systemDefault()
+        );
+        resultActions
+                .andExpect(handler().handlerType(PaymentController.class))
+                .andExpect(handler().methodName("pay"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.msg").value("결제에 성공했습니다."))
+                .andExpect(jsonPath("$.data.paymentId").value(1))
+                .andExpect(jsonPath("$.data.merchantUid").value("TESTUID123"))
+                .andExpect(jsonPath("$.data.amount").value(123))
+                .andExpect(jsonPath("$.data.paidAt").value(currentDateTime.toString()));
+
+    }
+
+    @Test
+    @DisplayName("결제 내역 조회")
+    void t3() throws Exception {
+        // 결제 내역 GET 요청
+        ResultActions resultActions = mvc
+                .perform(get("/api/bookings/payments/1"))
+                .andDo(print());
+
+        // 검증
+        resultActions
+                .andExpect(handler().handlerType(PaymentController.class))
+                .andExpect(handler().methodName("getPayment"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("결제 정보 조회에 성공했습니다."))
+                .andExpect(jsonPath("$.data.paymentId").value(1))
+                .andExpect(jsonPath("$.data.merchantUid").value("TESTUID123"))
+                .andExpect(jsonPath("$.data.amount").value(123));
+    }
+
+    @Test
+    @DisplayName("결제 내역 취소")
+    void t4() throws Exception {
+        // 결제 내역 취소 DELETE 요청
+        ResultActions resultActions = mvc
+                .perform(delete("/api/bookings/payments/1"))
+                .andDo(print());
+
+        // 검증
+        resultActions
+                .andExpect(handler().handlerType(PaymentController.class))
+                .andExpect(handler().methodName("cancel"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("결제 취소에 성공했습니다."))
+                .andExpect(jsonPath("$.data.paymentId").value(1))
+                .andExpect(jsonPath("$.data.merchantUid").value("TESTUID123"))
+                .andExpect(jsonPath("$.data.amount").value(123))
+                .andExpect(jsonPath("$.data.paymentStatus").value("CANCELLED"));
+    }
+}


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
- 인가 관련하여 각 api에 주석 남겨두었습니다
- 원래 결제 기능과 예약 기능을 독립적으로 설계하여 프론트에서 결제와 예약 api를 순차적으로 호출할 생각이었는데, 이러면 제가 의도하는 트랜잭션 처리가 번거로울 것같아 예약 api가 결제까지 진행하도록 로직을 변경했습니다. 다만 결제 api는 남겨두어서 단위 테스트는 가능하도록 했습니다
- api는 아직 테스트 못했지만 충돌은 없는 상태입니다. 빠른 시일 내로 테스트 예정입니다