### PR TITLE
[FEAT] [FE] 객실 상세 페이지 생성 및 클릭 이벤트 추가, 유저에 따라 반응 url 다르게 추가

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,17 +2,11 @@
 const nextConfig = {
   images: {
     domains: [
-      'i.postimg.cc',
-      'hotel-8ecb-416c-4c87.s3.us-east-1.amazonaws.com'
+      "i.postimg.cc",
+      "hotel-8ecb-416c-4c87.s3.us-east-1.amazonaws.com",
+      "hotel-8ecb-416c-4c87.s3.amazonaws.com",
     ],
   },
-}
-
-module.exports = {
-  images: {
-    domains: [],
-  },
-}
-
+};
 
 export default nextConfig;

--- a/frontend/src/app/business/hotel/management/page.tsx
+++ b/frontend/src/app/business/hotel/management/page.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { findHotelDetail } from "@/lib/api/BusinessHotelApi";
 import { GetHotelDetailResponse } from "@/lib/types/hotel/GetHotelDetailResponse";
 import { useEffect, useState } from "react";
-import RoomList from "@/components/business/room/RoomList";
+import RoomList from "@/components/business/rooms/RoomList";
 import HotelImages from "@/components/business/hotel/HotelImages";
 import { getRoleFromCookie } from "@/lib/utils/CookieUtil";
 import Navigation from "@/components/navigation/Navigation";

--- a/frontend/src/app/business/hotel/management/rooms/[roomId]/page.tsx
+++ b/frontend/src/app/business/hotel/management/rooms/[roomId]/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import RoomDetail from "@/components/business/rooms/RoomDetail";
+import { Card, CardContent } from "@/components/ui/card";
+import { findRoomDetail } from "@/lib/api/BusinessRoomApi";
+import { GetRoomDetailResponse } from "@/lib/types/room/GetRoomDetailResponse";
+import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import RoomImages from "@/components/business/rooms/RoomImages";
+import Navigation from "@/components/navigation/Navigation";
+import { getRoleFromCookie } from "@/lib/utils/CookieUtil";
+
+const RoomDetailPage: React.FC = () => {
+  const cookie = getRoleFromCookie();
+  const hotelId = Number(cookie?.hotelId);
+  const [roomDetail, setRoomDetail] = useState<GetRoomDetailResponse | null>(
+    null
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const params = useParams();
+  const roomsId = params.roomsId;
+
+  useEffect(() => {
+    const fetchRoomDetail = async () => {
+      try {
+        console.log("호텔 Id : ", Number(hotelId));
+        console.log("객실 Id : ", Number(roomsId));
+        const response = await findRoomDetail(Number(hotelId), Number(roomsId));
+        setRoomDetail(response);
+      } catch (error) {
+        throw error;
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchRoomDetail();
+  }, [hotelId, roomsId]);
+
+  if (isLoading) {
+    return <div className="text-center">로딩 중...</div>;
+  }
+
+  if (!roomDetail) {
+    return <div className="text-center">객실 정보를 불러올 수가 없습니다.</div>;
+  }
+
+  return (
+    <div className="p-4 pt-[100px]">
+      <Navigation />
+      <Card>
+        <CardContent>
+          <RoomImages images={roomDetail.roomImageUrls} />
+          <RoomDetail room={roomDetail} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default RoomDetailPage;

--- a/frontend/src/app/business/rooms/[roomId]/page.tsx
+++ b/frontend/src/app/business/rooms/[roomId]/page.tsx
@@ -84,6 +84,8 @@ export default function ModifyRoomPage() {
   useEffect(() => {
     const fetchRoomData = async () => {
       try {
+        console.log("호텔 Id : ", Number(hotelId));
+        console.log("객실 Id : ", Number(roomId));
         const response = await findRoomDetail(hotelId, roomId);
         const bedTypeNumber = response.roomDto.bedTypeNumber;
         setRoomId(response.roomDto.id);
@@ -92,7 +94,7 @@ export default function ModifyRoomPage() {
         setBasePrice(response.roomDto.basePrice);
         setStandardNumber(response.roomDto.standardNumber);
         setMaxNumber(response.roomDto.maxNumber);
-        setBedTypeNumber(response.roomDto.bedTypeNumber);
+        setBedTypeNumber(bedTypeNumber);
         setExistingImages(response.roomImageUrls);
         setRoomOptions(new Set(response.roomDto.roomOptions || []));
         console.log("객실 정보: ", response);

--- a/frontend/src/app/hotels/[hotelId]/page.tsx
+++ b/frontend/src/app/hotels/[hotelId]/page.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import HotelDetail from "@/components/business/hotel/HotelDetail";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { findHotelDetail } from "@/lib/api/BusinessHotelApi";
 import { GetHotelDetailResponse } from "@/lib/types/hotel/GetHotelDetailResponse";
-import { useParams, useSearchParams } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
-import RoomList from "@/components/business/room/RoomList";
+import RoomList from "@/components/business/rooms/RoomList";
 import HotelImages from "@/components/business/hotel/HotelImages";
 import Navigation from "@/components/navigation/Navigation";
 
@@ -17,6 +17,7 @@ const HotelDetailPage: React.FC = () => {
   );
   const [isLoading, setIsLoading] = useState(true);
   const searchParams = useSearchParams();
+  const router = useRouter();
   const checkInDate = searchParams.get("checkInDate") || "";
   const checkoutDate = searchParams.get("checkoutDate") || "";
 

--- a/frontend/src/app/hotels/[hotelId]/rooms/[roomId]/page.tsx
+++ b/frontend/src/app/hotels/[hotelId]/rooms/[roomId]/page.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import RoomDetail from "@/components/business/rooms/RoomDetail";
+import { Card, CardContent } from "@/components/ui/card";
+import { findRoomDetail } from "@/lib/api/BusinessRoomApi";
+import { GetRoomDetailResponse } from "@/lib/types/room/GetRoomDetailResponse";
+import { useParams, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import RoomImages from "@/components/business/rooms/RoomImages";
+import Navigation from "@/components/navigation/Navigation";
+
+const RoomDetailPage: React.FC = () => {
+  const params = useParams();
+  const [roomDetail, setRoomDetail] = useState<GetRoomDetailResponse | null>(
+    null
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const hotelId = params.hotelId;
+  const roomId = params.roomId;
+  const searchParams = useSearchParams();
+  const checkInDate = searchParams.get("checkInDate") || "";
+  const checkoutDate = searchParams.get("checkoutDate") || "";
+
+  useEffect(() => {
+    const fetchRoomDetail = async () => {
+      try {
+        console.log("페이지 호텔 Id : ", Number(hotelId));
+        console.log("페이지 객실 Id : ", Number(roomId));
+        const response = await findRoomDetail(Number(hotelId), Number(roomId));
+        setRoomDetail(response);
+      } catch (error) {
+        throw error;
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchRoomDetail();
+  }, [hotelId, roomId]);
+
+  if (isLoading) {
+    return <div className="text-center">로딩 중...</div>;
+  }
+
+  if (!roomDetail) {
+    return <div className="text-center">객실 정보를 불러올 수가 없습니다.</div>;
+  }
+
+  return (
+    <div className="p-4 pt-[100px]">
+      <Navigation />
+      <Card>
+        <CardContent>
+          <RoomImages images={roomDetail.roomImageUrls} />
+          <RoomDetail
+            room={roomDetail}
+            checkInDate={checkInDate}
+            checkoutDate={checkoutDate}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default RoomDetailPage;

--- a/frontend/src/components/business/hotel/HotelDetail.tsx
+++ b/frontend/src/components/business/hotel/HotelDetail.tsx
@@ -43,7 +43,7 @@ const HotelDetail: React.FC<HotelDetailProps> = ({ hotel }) => {
       setCanEdit(false);
     }
     hotel.hotelOptions = new Set(hotel.hotelOptions);
-  }, [cookie, param.hotelId]);
+  }, [cookie, hotelId]);
 
   const handleEdit = (hotelId: number) => {
     router.push(`/business/hotel/${hotelId}`);

--- a/frontend/src/components/business/rooms/RoomDetail.tsx
+++ b/frontend/src/components/business/rooms/RoomDetail.tsx
@@ -1,0 +1,187 @@
+import { Button } from "@/components/ui/button";
+import { deleteRoom } from "@/lib/api/BusinessRoomApi";
+import { GetRoomDetailResponse } from "@/lib/types/room/GetRoomDetailResponse";
+import { getRoleFromCookie } from "@/lib/utils/CookieUtil";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { FaBed, FaUsers, FaTag, FaCheckCircle } from "react-icons/fa";
+
+interface RoomDetailProps {
+  room: GetRoomDetailResponse;
+  checkInDate?: string;
+  checkoutDate?: string;
+}
+
+const RoomDetail: React.FC<RoomDetailProps> = ({ room }) => {
+  const cookie = getRoleFromCookie();
+  const [hotelId, setHotelId] = useState(-1);
+  const roomId = room.roomDto.id;
+  const [isBusinessUser, setIsBusinessUser] = useState<boolean>(false);
+  const [canEdit, setCanEdit] = useState<boolean>(false);
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const param = useParams();
+  const roomDto = room.roomDto;
+  const checkInDate = searchParams.get("checkInDate") || "";
+  const checkoutDate = searchParams.get("checkoutDate") || "";
+
+  useEffect(() => {
+    const cookieHotelId = cookie?.hotelId ? Number(cookie.hotelId) : -1;
+    const paramHotelId = param.hotelId ? Number(param.hotelId) : null;
+
+    console.log("현재 객실 Id : ", roomId);
+    console.log("쿠키 호텔 ID : ", cookieHotelId);
+    console.log("파람 호텔 ID : ", paramHotelId);
+    console.log("파람 객실 ID : ", roomId);
+
+    setIsBusinessUser(cookie?.role == "BUSINESS");
+
+    if (paramHotelId !== null) {
+      setHotelId(paramHotelId);
+      setCanEdit(isBusinessUser && cookieHotelId === paramHotelId);
+    } else if (isBusinessUser) {
+      setHotelId(cookieHotelId);
+      setCanEdit(true);
+    } else {
+      setCanEdit(false);
+    }
+    room.roomDto.roomOptions = new Set(room.roomDto.roomOptions);
+  }, [cookie, hotelId, roomId]);
+
+  const handleEdit = (roomId: number) => {
+    router.push(`/business/rooms/${roomId}`);
+  };
+
+  const handleDelete = async (hotelId: number) => {
+    if (!window.confirm("객실을 삭제하시겠습니까?")) return;
+
+    try {
+      await deleteRoom(hotelId, roomId);
+      alert("객실이 삭제되었습니다.");
+      router.push("/business/hotel/management");
+    } catch (error) {
+      if (error instanceof Error) {
+        alert(error.message);
+      }
+    }
+  };
+
+  const handleReservation = (roomId: number) => {
+    const params = new URLSearchParams();
+    params.set("hotel", (hotelId ?? "").toString());
+    params.set("rooms", roomId.toString());
+    if (checkInDate) params.set("checkInDate", checkInDate);
+    if (checkoutDate) params.set("checkoutDate", checkoutDate);
+
+    console.log(
+      "예약 페이지로 이동 URL : ",
+      `/orders/payment?${params.toString()}`
+    );
+    router.push(`/orders/payment?${params.toString()}`);
+  };
+
+  return (
+    <div className="bg-white p-8 shadow-lg rounded-2xl border border-gray-200">
+      {/* 방 이름 */}
+      <div className="text-center mb-8">
+        <h2 className="text-4xl font-extrabold text-pink-500">
+          {roomDto.roomName}
+        </h2>
+      </div>
+
+      {/* 방 기본 정보 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 text-lg text-gray-700">
+        {[
+          {
+            icon: FaTag,
+            label: "기본 가격",
+            value: `${roomDto.basePrice.toLocaleString()}원`,
+            color: "text-green-500",
+          },
+          {
+            icon: FaUsers,
+            label: "기준 인원",
+            value: `${roomDto.standardNumber}명`,
+            color: "text-blue-500",
+          },
+          {
+            icon: FaUsers,
+            label: "최대 인원",
+            value: `${roomDto.maxNumber}명`,
+            color: "text-red-500",
+          },
+          {
+            icon: FaBed,
+            label: "침대 타입",
+            value: Object.entries(roomDto.bedTypeNumber)
+              .filter(([_, count]) => count > 0)
+              .map(([type, count]) => `${type} (${count}개)`)
+              .join(", "),
+            color: "text-purple-500",
+          },
+          {
+            icon: FaUsers,
+            label: "보유 객실 수",
+            value: `${roomDto.roomNumber}개`,
+            color: "text-orange-500",
+          },
+        ].map(({ icon: Icon, label, value, color }, index) => (
+          <div
+            key={index}
+            className="flex items-center gap-4 bg-gray-50 p-4 rounded-lg shadow-sm"
+          >
+            <Icon className={`${color} text-2xl`} />
+            <p className="text-gray-900 font-semibold">{label} :</p>
+            <span className="text-gray-700">{value}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* 객실 옵션 */}
+      <div className="mt-8 bg-gray-100 p-6 rounded-xl">
+        <h3 className="text-xl font-bold text-gray-900 mb-4">객실 옵션</h3>
+        <div className="flex flex-wrap gap-4">
+          {roomDto.roomOptions.size > 0 ? (
+            Array.from(roomDto.roomOptions).map((option) => (
+              <span
+                key={option}
+                className="flex items-center gap-2 bg-white border px-4 py-2 rounded-full shadow-sm"
+              >
+                <FaCheckCircle className="text-green-500" />
+                {option}
+              </span>
+            ))
+          ) : (
+            <p className="text-gray-500">제공되는 옵션이 없습니다.</p>
+          )}
+        </div>
+      </div>
+
+      {/* 버튼 섹션 */}
+      <div className="mt-4 flex justify-end gap-2">
+        {isBusinessUser && canEdit ? (
+          <>
+            <Button
+              className="bg-blue-500 text-white"
+              onClick={() => handleEdit(roomId)}
+            >
+              수정
+            </Button>
+            <Button variant="destructive" onClick={() => handleDelete(roomId)}>
+              삭제
+            </Button>
+          </>
+        ) : (
+          <Button
+            className="bg-green-500 text-white"
+            onClick={() => handleReservation(roomId)}
+          >
+            예약하기
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default RoomDetail;

--- a/frontend/src/components/business/rooms/RoomImages.tsx
+++ b/frontend/src/components/business/rooms/RoomImages.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { Swiper, SwiperSlide } from "swiper/react";
+import { Navigation } from "swiper/modules";
+import "swiper/css";
+import "swiper/css/navigation";
+import { useState } from "react";
+import { FaImage } from "react-icons/fa"; // 아이콘 추가
+
+interface RoomImagesProps {
+  images: string[];
+}
+
+const RoomImages: React.FC<RoomImagesProps> = ({ images }) => {
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+
+  return (
+    <div className="container mx-auto px-6">
+      {/* 객실 이미지 제목 */}
+      <div className="text-center mb-8">
+        <h2 className="text-4xl font-bold text-sky-500">
+          <span className="border-b-4 border-yellow-300 inline-block px-4">
+            객실 이미지 갤러리
+          </span>
+        </h2>
+        <p className="text-lg text-gray-600 mt-2">
+          객실의 매력을 미리 경험해보세요!
+        </p>
+      </div>
+
+      {/* 이미지 슬라이더 */}
+      {images.length > 0 ? (
+        <div className="relative">
+          <Swiper
+            modules={[Navigation]}
+            spaceBetween={15}
+            slidesPerView={3}
+            navigation
+            loop={true}
+            className="rounded-xl shadow-lg border border-gray-200"
+          >
+            {images.map((src, index) => (
+              <SwiperSlide key={index}>
+                <img
+                  src={src}
+                  alt={`객실 이미지 ${index + 1}`}
+                  className="w-full h-64 object-cover rounded-lg cursor-pointer transition-transform duration-300 hover:scale-105"
+                  onClick={() => setSelectedImage(src)}
+                />
+              </SwiperSlide>
+            ))}
+          </Swiper>
+        </div>
+      ) : (
+        <div className="flex flex-col items-center justify-center bg-gray-100 p-8 rounded-xl shadow-md">
+          <FaImage className="text-gray-400 text-6xl mb-4" />
+          <p className="text-gray-500 text-xl font-semibold">
+            등록된 객실 이미지가 없습니다.
+          </p>
+        </div>
+      )}
+
+      {/* 모달 - 이미지 확대 */}
+      {selectedImage && (
+        <div
+          className="fixed inset-0 bg-black bg-opacity-80 flex items-center justify-center z-50"
+          onClick={() => setSelectedImage(null)}
+        >
+          <div className="relative p-4 bg-white rounded-2xl shadow-2xl max-w-3xl">
+            <button
+              className="absolute top-2 right-2 text-gray-600 hover:text-gray-900 text-3xl font-bold"
+              onClick={() => setSelectedImage(null)}
+            >
+              ✖
+            </button>
+            <img
+              src={selectedImage}
+              alt="확대한 이미지"
+              className="w-full max-h-[80vh] object-contain rounded-lg"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RoomImages;


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [ ] BE
- [x] FE

  <br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
- 객실 상세 페이지 생성
- 객실 리스트의 객실 컴포넌트 클릭 시 상세 페이지로 이동
- 유저의 Role에 따라 checkInDate와 checkoutDate를 구분해서 searchParams URL로 전송
