### PR TITLE
[FEAT] [BE] 로깅 설정 및 AOP 적용

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -44,3 +44,4 @@ src/main/resources/application-secret.yml
 src/main/resources/application-api-keys.yml
 src/main/resources/application-business-api.yml
 src/main/java/com/ll/hotel/global/initData/BaseInit.java
+logs/

--- a/backend/src/main/java/com/ll/hotel/global/aspect/GlobalExceptionAspect.java
+++ b/backend/src/main/java/com/ll/hotel/global/aspect/GlobalExceptionAspect.java
@@ -1,0 +1,48 @@
+package com.ll.hotel.global.aspect;
+
+import com.ll.hotel.global.exceptions.CustomS3Exception;
+import com.ll.hotel.global.exceptions.ServiceException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+@Aspect
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class GlobalExceptionAspect {
+    @AfterThrowing(pointcut = "@within(org.springframework.stereotype.Service)", throwing = "ex")
+
+    public void handleException(JoinPoint joinPoint, Exception ex) {
+        String className = joinPoint.getSignature().getDeclaringType().getSimpleName();
+        String methodName = joinPoint.getSignature().getName();
+        String status;
+        String msg;
+
+        if (ex instanceof ServiceException) {
+            ServiceException exception = (ServiceException) ex;
+            status = exception.getResultCode().toString();
+            msg = exception.getMsg();
+        } else if (ex instanceof CustomS3Exception) {
+            CustomS3Exception exception = (CustomS3Exception) ex;
+            status = exception.getResultCode().toString();
+            msg = exception.getMsg();
+        } else if (ex instanceof MethodArgumentNotValidException) {
+            MethodArgumentNotValidException exception = (MethodArgumentNotValidException) ex;
+            status = HttpStatus.BAD_REQUEST.toString();
+            msg = exception.getMessage();
+        } else {
+            status = "UNKNOWN";
+            msg = ex.getMessage();
+        }
+
+        log.error("ERROR = [{}.{}], status: [{}], message: [{}]",
+                className, methodName, status, msg
+        );
+    }
+}

--- a/backend/src/main/java/com/ll/hotel/global/aspect/ResponseAspect.java
+++ b/backend/src/main/java/com/ll/hotel/global/aspect/ResponseAspect.java
@@ -1,14 +1,18 @@
 package com.ll.hotel.global.aspect;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ll.hotel.global.app.AppConfig;
 import com.ll.hotel.global.rsData.RsData;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.stereotype.Component;
 
 @Aspect
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ResponseAspect {
@@ -37,10 +41,22 @@ public class ResponseAspect {
             @annotation(org.springframework.web.bind.annotation.ResponseBody)
             """)
     public Object handleResponse(ProceedingJoinPoint joinPoint) throws Throwable {
+        String className = joinPoint.getSignature().getDeclaringTypeName();
+        String methodName = joinPoint.getSignature().getName();
+
+        log.info("Request = [{}.{}]", className, methodName);
+
         Object proceed = joinPoint.proceed();
 
         if (proceed instanceof RsData<?>) {
             RsData<?> rsData = (RsData<?>) proceed;
+            ObjectMapper objectMapper = AppConfig.getObjectMapper();
+            String jsonData = objectMapper.writeValueAsString(rsData.getData());
+
+            log.info("Response = [{}.{}], status: [{}], message: [{}], data: [{}]",
+                    className, methodName, rsData.getResultCode(), rsData.getMsg(), jsonData
+            );
+
             response.setStatus(rsData.getResultCode().value());
         }
 

--- a/backend/src/main/java/com/ll/hotel/global/globalExceptionHandler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/ll/hotel/global/globalExceptionHandler/GlobalExceptionHandler.java
@@ -2,8 +2,10 @@ package com.ll.hotel.global.globalExceptionHandler;
 
 import com.ll.hotel.global.exceptions.CustomS3Exception;
 import com.ll.hotel.global.exceptions.ServiceException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -33,7 +35,17 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<String> handleValidationException(MethodArgumentNotValidException ex) {
-        return ResponseEntity.badRequest().body("Validation failed: " + ex.getBindingResult().toString());
+        List<FieldError> fieldErrors = ex.getBindingResult().getFieldErrors();
+
+        StringBuilder errorMessages = new StringBuilder();
+        for (FieldError fieldError : fieldErrors) {
+            errorMessages.append(fieldError.getField())
+                    .append(": ")
+                    .append(fieldError.getDefaultMessage())
+                    .append("\n");
+        }
+
+        return ResponseEntity.badRequest().body(errorMessages.toString());
     }
 
 }

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -2,5 +2,15 @@ spring:
   datasource:
     url: jdbc:h2:mem:db_test;MODE=MySQL
 
+  cloud:
+    aws:
+      s3:
+        bucket: test-bucket
+      credentials:
+        access-key: test-access-key
+        secret-key: test-secret-key
+      region:
+        static: us-east-1
+
 app:
   mode: TEST

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -2,16 +2,6 @@ spring:
   application:
     name: hotel
 
-  cloud:
-    aws:
-      s3:
-        bucket: test-bucket
-      credentials:
-        access-key: test-access-key
-        secret-key: test-secret-key
-      region:
-        static: us-east-1
-
   data:
     redis:
       host: localhost

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- 로그 파일 기본 경로 및 이름 -->
+    <property name="LOG_DIR" value="./logs/"/>
+    <property name="LOG_FILE_NAME" value="info/info"/>
+    <property name="ERROR_LOG_FILE_NAME" value="error/error"/>
+    <property name="SQL_LOG_FILE_NAME" value="sql/sql"/>
+
+    <!-- 콘솔 출력 Appender -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %magenta(%-4relative) --- [ %thread{10} ]
+                %cyan(%logger{20}) : %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <!-- 성공 로그 파일 Appender -->
+    <appender name="LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/${LOG_FILE_NAME}.log</file>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>DENY</onMatch>
+            <onMismatch>ACCEPT</onMismatch>
+        </filter>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_DIR}/${LOG_FILE_NAME}-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- ERROR 로그 파일 Appender -->
+    <appender name="ERROR_LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/${ERROR_LOG_FILE_NAME}.log</file>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_DIR}/${ERROR_LOG_FILE_NAME}-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- INFO 로거 -->
+    <logger name="com.ll.hotel.global.aspect.ResponseAspect" level="INFO" additivity="false">
+        <appender-ref ref="LOG_FILE"/>
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <!-- ERROR 로거 -->
+    <logger name="com.ll.hotel.global.aspect.GlobalExceptionAspect" level="ERROR" additivity="false">
+        <appender-ref ref="ERROR_LOG_FILE"/>
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <!-- ROOT 로거: 콘솔 출력만 -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
- 로그 설정
  - INFO, ERROR 별로 따로 파일로 저장
- RsData 정상 응답 시 : AOP를 통해 logs/info/info.log 파일에 저장
- GlobalExceptionHandler의 예외 발생 시 : AOP를 통해 logs/error/error.log 파일에 저장
  - 중복 방지 위해 @Service 에서만 로깅하도록 적용
 - Validation 에러 메시지를 `[field]: defaultMessage` 형식으로 변경