### PR TITLE
[REFACTOR] [BE] 즐겨찾기 오버 플로우 관련 코드 개선

### DIFF
--- a/backend/src/main/java/com/ll/hotel/domain/hotel/hotel/dto/HotelDto.java
+++ b/backend/src/main/java/com/ll/hotel/domain/hotel/hotel/dto/HotelDto.java
@@ -1,14 +1,16 @@
 package com.ll.hotel.domain.hotel.hotel.dto;
 
-import com.ll.hotel.domain.hotel.hotel.entity.Hotel;
-import com.ll.hotel.domain.hotel.option.entity.HotelOption;
-import com.ll.hotel.domain.hotel.room.entity.Room;
-import jakarta.validation.constraints.NotBlank;
 import java.time.LocalTime;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import com.ll.hotel.domain.hotel.hotel.entity.Hotel;
+import com.ll.hotel.domain.hotel.option.entity.HotelOption;
+
+import jakarta.validation.constraints.NotBlank;
 import lombok.NonNull;
 
 public record HotelDto(
@@ -44,11 +46,10 @@ public record HotelDto(
         @NotBlank
         String hotelStatus,
 
-        List<Room> rooms,
+        List<?> rooms,
 
         Set<String> hotelOptions
 
-        // 호텔 Favorite
 ) {
     public HotelDto(Hotel hotel) {
         this(
@@ -68,6 +69,41 @@ public record HotelDto(
                         ? hotel.getHotelOptions().stream()
                         .map(HotelOption::getName)
                         .collect(Collectors.toSet())
+                        : new HashSet<>()
+        );
+    }
+    
+    // 즐겨찾기 목록 조회 간소화 DTO
+    public HotelDto(
+            long hotelId,
+            String hotelName,
+            String hotelEmail,
+            String hotelPhoneNumber,
+            String streetAddress,
+            Integer zipCode,
+            Integer hotelGrade,
+            LocalTime checkInTime,
+            LocalTime checkOutTime,
+            String hotelExplainContent,
+            String hotelStatus,
+            List<Map<String, Object>> simplifiedRooms,
+            List<String> hotelOptionNames
+    ) {
+        this(
+                hotelId,
+                hotelName,
+                hotelEmail,
+                hotelPhoneNumber,
+                streetAddress,
+                zipCode,
+                hotelGrade,
+                checkInTime,
+                checkOutTime,
+                hotelExplainContent,
+                hotelStatus,
+                simplifiedRooms,
+                hotelOptionNames != null
+                        ? new HashSet<>(hotelOptionNames)
                         : new HashSet<>()
         );
     }

--- a/backend/src/main/java/com/ll/hotel/domain/member/member/service/MemberService.java
+++ b/backend/src/main/java/com/ll/hotel/domain/member/member/service/MemberService.java
@@ -4,6 +4,7 @@ package com.ll.hotel.domain.member.member.service;
 import com.ll.hotel.domain.hotel.hotel.dto.HotelDto;
 import com.ll.hotel.domain.hotel.hotel.entity.Hotel;
 import com.ll.hotel.domain.hotel.hotel.repository.HotelRepository;
+import com.ll.hotel.domain.hotel.option.entity.HotelOption;
 import com.ll.hotel.domain.member.member.dto.JoinRequest;
 import com.ll.hotel.domain.member.member.entity.Member;
 import com.ll.hotel.domain.member.member.repository.MemberRepository;
@@ -260,7 +261,40 @@ public class MemberService {
         return favorites.stream()
             .map(hotel -> {
                 log.debug("getFavoriteHotels - hotel: {}", hotel.getHotelName());
-                return new HotelDto(hotel);
+                
+                // 즐겨찾기를 프론트로 넘길 때 많은 데이터를 넘기면 프론트에서 받지 못하는 부분이 있어 간소화
+                List<Map<String, Object>> simplifiedRooms = hotel.getRooms().stream()
+                    .map(room -> {
+                        Map<String, Object> roomMap = new HashMap<>();
+                        roomMap.put("id", room.getId());
+                        roomMap.put("roomName", room.getRoomName());
+                        roomMap.put("roomNumber", room.getRoomNumber());
+                        roomMap.put("basePrice", room.getBasePrice());
+                        return roomMap;
+                    })
+                    .collect(Collectors.toList());
+                
+                List<String> hotelOptionNames = hotel.getHotelOptions() != null
+                    ? hotel.getHotelOptions().stream()
+                        .map(HotelOption::getName)
+                        .collect(Collectors.toList())
+                    : new ArrayList<>();
+                
+                return new HotelDto(
+                    hotel.getId(),
+                    hotel.getHotelName(),
+                    hotel.getHotelEmail(),
+                    hotel.getHotelPhoneNumber(),
+                    hotel.getStreetAddress(),
+                    hotel.getZipCode(),
+                    hotel.getHotelGrade(),
+                    hotel.getCheckInTime(),
+                    hotel.getCheckOutTime(),
+                    hotel.getHotelExplainContent(),
+                    hotel.getHotelStatus().getValue(),
+                    simplifiedRooms,
+                    hotelOptionNames
+                );
             })
             .collect(Collectors.toList());
     }


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [] 새로운 기능 추가
- [x] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
- 기능에서 어떤 부분이 구현되었는지 설명해주세요
- 기존 호텔 즐겨찾기가 1개 이상 추가가 되지 않던 부분 해결
- 호텔 DTO 쪽에서 Room에 대한 데이터까지 전부 DTO로 만들어 프론트로 넘길 때 백엔드에서는 정상적으로 데이터를 생성하지만, 프론트 쪽에선 데이터를 받다가 오버 플로우가 생겨 데이터를 전부 받지 못하고 1개 씩 받는 현상
