### PR TITLE
[REFACTOR] [BE] AOP 로그 출력 형식 변경, 호출되는 서비스도 로그파일에 추가

### DIFF
--- a/backend/src/main/java/com/ll/hotel/global/aspect/GlobalExceptionLoggingAspect.java
+++ b/backend/src/main/java/com/ll/hotel/global/aspect/GlobalExceptionLoggingAspect.java
@@ -15,10 +15,9 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 @Component
 @Slf4j
 @RequiredArgsConstructor
-public class GlobalExceptionAspect {
+public class GlobalExceptionLoggingAspect {
     @AfterThrowing(pointcut = "@within(org.springframework.stereotype.Service)", throwing = "ex")
-
-    public void handleException(JoinPoint joinPoint, Exception ex) {
+    public void logGlobalException(JoinPoint joinPoint, Throwable ex) {
         String className = joinPoint.getSignature().getDeclaringType().getSimpleName();
         String methodName = joinPoint.getSignature().getName();
         String status;

--- a/backend/src/main/java/com/ll/hotel/global/aspect/ResponseAspect.java
+++ b/backend/src/main/java/com/ll/hotel/global/aspect/ResponseAspect.java
@@ -41,10 +41,10 @@ public class ResponseAspect {
             @annotation(org.springframework.web.bind.annotation.ResponseBody)
             """)
     public Object handleResponse(ProceedingJoinPoint joinPoint) throws Throwable {
-        String className = joinPoint.getSignature().getDeclaringTypeName();
+        String className = joinPoint.getSignature().getDeclaringType().getSimpleName();
         String methodName = joinPoint.getSignature().getName();
 
-        log.info("Request = [{}.{}]", className, methodName);
+        log.info("Request Controller = [{}.{}]", className, methodName);
 
         Object proceed = joinPoint.proceed();
 
@@ -52,7 +52,7 @@ public class ResponseAspect {
             ObjectMapper objectMapper = AppConfig.getObjectMapper();
             String jsonData = objectMapper.writeValueAsString(rsData.getData());
 
-            log.info("Response = [{}.{}], status: [{}], message: [{}], data: [{}]",
+            log.info("Response Controller = [{}.{}], status: [{}], message: [{}], data: [{}]",
                     className, methodName, rsData.getResultCode(), rsData.getMsg(), jsonData
             );
 

--- a/backend/src/main/java/com/ll/hotel/global/aspect/ServiceLoggingAspect.java
+++ b/backend/src/main/java/com/ll/hotel/global/aspect/ServiceLoggingAspect.java
@@ -1,0 +1,23 @@
+package com.ll.hotel.global.aspect;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ServiceLoggingAspect {
+    @Before("@within(org.springframework.stereotype.Service)")
+    public Object logService(JoinPoint joinPoint) {
+        String className = joinPoint.getSignature().getDeclaringType().getSimpleName();
+        String methodName = joinPoint.getSignature().getName();
+        log.info("Request Service = [{}.{}]", className, methodName);
+
+        return joinPoint;
+    }
+}

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -54,13 +54,13 @@
     </springProfile>
 
     <!-- INFO 로거 -->
-    <logger name="com.ll.hotel.global.aspect.ResponseAspect" level="INFO" additivity="false">
+    <logger name="com.ll.hotel.global" level="INFO" additivity="false">
         <appender-ref ref="LOG_FILE"/>
         <appender-ref ref="CONSOLE"/>
     </logger>
 
     <!-- ERROR 로거 -->
-    <logger name="com.ll.hotel.global.aspect.GlobalExceptionAspect" level="ERROR" additivity="false">
+    <logger name="com.ll.hotel.global.aspect.GlobalExceptionLoggingAspect" level="ERROR" additivity="false">
         <appender-ref ref="ERROR_LOG_FILE"/>
         <appender-ref ref="CONSOLE"/>
     </logger>


### PR DESCRIPTION
<!-- 제목 : [FEAT] [BE] 구현한 기능 -->
<!-- #[이슈 번호] -->

## 📝Part
- [x] BE
- [ ] FE

  <br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 문서 작업
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 서비스 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
- 로그 출력 형식 변경
  - `Controller` : __Request Controller__ 와 __Response Controller__ 를 모두 로그 파일에 저장
  - `Service` : 호출되는 __Service__ 를 로그 파일에 저장